### PR TITLE
次のレッスンを行う際に前のレッスンの最初の問題が読み上げられてしまうバグを修正

### DIFF
--- a/src/components/pages/lessons/index.tsx
+++ b/src/components/pages/lessons/index.tsx
@@ -56,6 +56,7 @@ const Index: FC<Props> = ({ handleClickMenuButton }) => {
       ...userSetting,
       lessonId: userSetting.lessonId ? nextLessonId : undefined,
     });
+    setFilteredQuestions(filterQuestionsByLessonId(questionData, nextLessonId));
     setLessonId(userSetting.lessonId ? nextLessonId : undefined);
     setJudgedAnswers([]);
     setCurrentQuestionNumber(1);

--- a/src/components/pages/lessons/index.tsx
+++ b/src/components/pages/lessons/index.tsx
@@ -54,7 +54,7 @@ const Index: FC<Props> = ({ handleClickMenuButton }) => {
 
     setUserSetting({
       ...userSetting,
-      lessonId: userSetting.lessonId ? nextLessonId : undefined,
+      lessonId: nextLessonId,
     });
     setFilteredQuestions(filterQuestionsByLessonId(questionData, nextLessonId));
     setLessonId(userSetting.lessonId ? nextLessonId : undefined);


### PR DESCRIPTION
[次のレッスンを行う際に前のレッスンの最初の問題が読み上げられてしまう · Issue \#53](https://github.com/SatoshiHaramura/stock-word/issues/53)